### PR TITLE
Regex fix

### DIFF
--- a/packages/parser-opts/src/index.ts
+++ b/packages/parser-opts/src/index.ts
@@ -1,4 +1,4 @@
-import { gitmojiCodeRegex, gitmojiUnicodeRegex, emojiRegex } from '@gitmoji/gitmoji-regex';
+import { emojiRegex, gitmojiCodeRegex, gitmojiUnicodeRegex } from '@gitmoji/gitmoji-regex';
 
 const gitmojiCodeStr = gitmojiCodeRegex.source;
 const gitmojiUnicodeStr = gitmojiUnicodeRegex.source;
@@ -7,7 +7,7 @@ const emojiStr = emojiRegex.source;
 export default {
   // Test URL: https://regex101.com/r/gYkG99/1
   headerPattern: new RegExp(
-    `^(?:${gitmojiCodeStr}|(?:${gitmojiUnicodeStr})|(?:${emojiStr}))\\s(?<type>\\w*)(?:\\((?<scope>.*)\\))?!?:\\s(?<subject>(?:(?!#).)*(?:(?!\\s).))(?:\\s\\(?(?<ticket>#\\d*)\\)?)?$`,
+    `^(?:${gitmojiCodeStr}|(?:${gitmojiUnicodeStr})|(?:${emojiStr}))\\s(?<type>[a-zA-z-,\/]+)(?:\\((?<scope>.*)\\))?!?:\\s(?<subject>(?:(?!#).)*(?:(?!\\s).))(?:\\s\\(?(?<ticket>#\\d*)\\)?)?$`,
   ),
 
   headerCorrespondence: ['type', 'scope', 'subject', 'ticket'],

--- a/packages/parser-opts/src/index.ts
+++ b/packages/parser-opts/src/index.ts
@@ -7,7 +7,7 @@ const emojiStr = emojiRegex.source;
 export default {
   // Test URL: https://regex101.com/r/gYkG99/1
   headerPattern: new RegExp(
-    `^(?:${gitmojiCodeStr}|(?:${gitmojiUnicodeStr})|(?:${emojiStr}))\\s(?<type>[a-zA-z-,\/]+)(?:\\((?<scope>.*)\\))?!?:\\s(?<subject>(?:(?!#).)*(?:(?!\\s).))(?:\\s\\(?(?<ticket>#\\d*)\\)?)?$`,
+    `^(?:${gitmojiCodeStr}|(?:${gitmojiUnicodeStr})|(?:${emojiStr}))\\s(?<type>[a-zA-Z-,\/]+)(?:\\((?<scope>.*)\\))?!?:\\s(?<subject>(?:(?!#).)*(?:(?!\\s).))(?:\\s\\(?(?<ticket>#\\d*)\\)?)?$`,
   ),
 
   headerCorrespondence: ['type', 'scope', 'subject', 'ticket'],


### PR DESCRIPTION
Allow for commit types to have '-' and '/' in them. i.e. fix-ci or ci/cd
fixes issue [#674](https://github.com/arvinxx/gitmoji-commit-workflow/issues/674)